### PR TITLE
fix: declare every key the config tools return (#94)

### DIFF
--- a/src/skill-config-tool.test.ts
+++ b/src/skill-config-tool.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Client } from "@modelcontextprotocol/client";
+import { McpServer, InMemoryTransport } from "@modelcontextprotocol/server";
+import { registerSkillConfigTool } from "./skill-config-tool.js";
+import { createTestSkillState } from "./__test-helpers__/helpers.js";
+
+/**
+ * These tests go through a real Client on purpose. The SDK only validates a tool's
+ * structuredContent against its advertised outputSchema after tools/list has been
+ * called, so a mismatch is invisible to a test that calls the handler directly.
+ * That is how #94 shipped: six tools returned more keys than they declared, and
+ * every client that had called tools/list got -32602 instead of a result.
+ */
+
+let configHome: string;
+let prevHome: string | undefined;
+let prevUserProfile: string | undefined;
+
+beforeEach(() => {
+  configHome = fs.mkdtempSync(path.join(os.tmpdir(), "skilljack-cfg-"));
+  prevHome = process.env.HOME;
+  prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = configHome;
+  process.env.USERPROFILE = configHome;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = prevUserProfile;
+  fs.rmSync(configHome, { recursive: true, force: true });
+});
+
+async function connect() {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerSkillConfigTool(server, createTestSkillState([]), () => {});
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("skill-config tool output schemas", () => {
+  it("every config tool's success result validates against its advertised outputSchema", async () => {
+    const client = await connect();
+    // Arms the SDK's output-schema validators. Without this the calls below pass
+    // regardless of whether the schemas are right.
+    const { tools } = await client.listTools();
+
+    const skillsDir = fs.mkdtempSync(path.join(os.tmpdir(), "skilljack-dir-"));
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ["skill-config", {}],
+      ["skill-config-add-directory", { directory: skillsDir }],
+      ["skill-config-remove-directory", { directory: skillsDir }],
+      ["skill-config-add-allowed-org", { org: "example-org" }],
+      ["skill-config-remove-allowed-org", { org: "example-org" }],
+      ["skill-config-add-allowed-origin", { origin: "https://example.com" }],
+      ["skill-config-remove-allowed-origin", { origin: "https://example.com" }],
+      ["skill-config-set-static-mode", { enabled: true }],
+    ];
+
+    for (const [name, args] of calls) {
+      expect(tools.map((t) => t.name)).toContain(name);
+      // Rejects with -32602 "data must NOT have additional properties" when the
+      // handler returns keys the outputSchema does not declare.
+      const result = await client.callTool({ name, arguments: args });
+      expect(result.isError, `${name} returned isError`).toBeFalsy();
+    }
+
+    fs.rmSync(skillsDir, { recursive: true, force: true });
+  });
+
+  it("declares every key the mutating tools actually return", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+
+    const returned = [
+      "success",
+      "directories",
+      "activeSource",
+      "isOverridden",
+      "staticMode",
+      "allowedOrgs",
+      "allowedUsers",
+      "allowedOrigins",
+      "error",
+    ];
+
+    for (const name of [
+      "skill-config-add-directory",
+      "skill-config-remove-directory",
+      "skill-config-add-allowed-org",
+      "skill-config-remove-allowed-org",
+      "skill-config-add-allowed-origin",
+      "skill-config-remove-allowed-origin",
+    ]) {
+      const tool = tools.find((t) => t.name === name);
+      const props = Object.keys(
+        (tool?.outputSchema as { properties?: Record<string, unknown> })?.properties ?? {}
+      );
+      expect(props.sort(), `${name} outputSchema`).toEqual([...returned].sort());
+    }
+  });
+});

--- a/src/skill-config-tool.ts
+++ b/src/skill-config-tool.ts
@@ -95,6 +95,27 @@ const DirectoryOutputSchema = z.object({
 });
 
 /**
+ * Output schema for the config tools that mutate state.
+ *
+ * On success they all return the same full config snapshot, so declaring anything
+ * narrower makes the tool unusable: the SDK stamps `additionalProperties: false` on
+ * the advertised outputSchema, and a client that has called tools/list rejects the
+ * result with -32602. The error paths return only a subset, so everything except
+ * `success` is optional.
+ */
+const ConfigMutationOutputSchema = z.object({
+  success: z.boolean(),
+  directories: z.array(DirectoryOutputSchema).optional(),
+  activeSource: z.string().optional(),
+  isOverridden: z.boolean().optional(),
+  staticMode: z.boolean().optional(),
+  allowedOrgs: z.array(z.string()).optional(),
+  allowedUsers: z.array(z.string()).optional(),
+  allowedOrigins: z.array(z.string()).optional(),
+  error: z.string().optional(),
+});
+
+/**
  * Callback type for when directories or GitHub settings change.
  */
 export type OnDirectoriesChangedCallback = () => void | Promise<void>;
@@ -227,13 +248,7 @@ export function registerSkillConfigTool(
       title: "Add Skills Directory",
       description: "Add a skills directory to the configuration.",
       inputSchema: AddDirectoryInputSchema,
-      outputSchema: z.object({
-        success: z.boolean(),
-        directories: z.array(DirectoryOutputSchema).optional(),
-        activeSource: z.string().optional(),
-        isOverridden: z.boolean().optional(),
-        error: z.string().optional(),
-      }),
+      outputSchema: ConfigMutationOutputSchema,
       _meta: {
         ui: {
           resourceUri: RESOURCE_URI,
@@ -300,13 +315,7 @@ export function registerSkillConfigTool(
       title: "Remove Skills Directory",
       description: "Remove a skills directory from the configuration.",
       inputSchema: RemoveDirectoryInputSchema,
-      outputSchema: z.object({
-        success: z.boolean(),
-        directories: z.array(DirectoryOutputSchema).optional(),
-        activeSource: z.string().optional(),
-        isOverridden: z.boolean().optional(),
-        error: z.string().optional(),
-      }),
+      outputSchema: ConfigMutationOutputSchema,
       _meta: {
         ui: {
           resourceUri: RESOURCE_URI,
@@ -375,11 +384,7 @@ export function registerSkillConfigTool(
       inputSchema: z.object({
         org: z.string().describe("GitHub organization name to allow"),
       }),
-      outputSchema: z.object({
-        success: z.boolean(),
-        allowedOrgs: z.array(z.string()),
-        error: z.string().optional(),
-      }),
+      outputSchema: ConfigMutationOutputSchema,
       _meta: {
         ui: {
           resourceUri: RESOURCE_URI,
@@ -450,11 +455,7 @@ export function registerSkillConfigTool(
       inputSchema: z.object({
         org: z.string().describe("GitHub organization name to remove"),
       }),
-      outputSchema: z.object({
-        success: z.boolean(),
-        allowedOrgs: z.array(z.string()),
-        error: z.string().optional(),
-      }),
+      outputSchema: ConfigMutationOutputSchema,
       _meta: {
         ui: {
           resourceUri: RESOURCE_URI,
@@ -530,11 +531,7 @@ export function registerSkillConfigTool(
             "Origin or full URL (e.g. https://example.com or https://example.com/.well-known/agent-skills/). Only the scheme + host[:port] is stored."
           ),
       }),
-      outputSchema: z.object({
-        success: z.boolean(),
-        allowedOrigins: z.array(z.string()),
-        error: z.string().optional(),
-      }),
+      outputSchema: ConfigMutationOutputSchema,
       _meta: {
         ui: {
           resourceUri: RESOURCE_URI,
@@ -614,11 +611,7 @@ export function registerSkillConfigTool(
       inputSchema: z.object({
         origin: z.string().describe("Origin to remove (exact match)"),
       }),
-      outputSchema: z.object({
-        success: z.boolean(),
-        allowedOrigins: z.array(z.string()),
-        error: z.string().optional(),
-      }),
+      outputSchema: ConfigMutationOutputSchema,
       _meta: {
         ui: {
           resourceUri: RESOURCE_URI,


### PR DESCRIPTION
Fixes #94.

Six `skill-config` tools returned an 8-key config snapshot but declared five. The SDK stamps `additionalProperties: false` on the advertised `outputSchema`, so any client that had called `tools/list` got `-32602 data must NOT have additional properties` instead of a result:

- `skill-config-add-directory`
- `skill-config-remove-directory`
- `skill-config-add-allowed-org`
- `skill-config-remove-allowed-org`
- `skill-config-add-allowed-origin`
- `skill-config-remove-allowed-origin`

Those are the `visibility: ["app"]` tools the config UI calls, so editing configuration from the UI failed. This predates the SDK v2 migration — v1 rejected it the same way.

## Fix

All six return the same snapshot on success and a subset on error, so they now share one `ConfigMutationOutputSchema` with `success` required and the rest optional, instead of six near-copies.

`skill-config-set-static-mode` already matched its schema and keeps its own narrower one — widening it would advertise fields it never returns.

## Test

Adds `src/skill-config-tool.test.ts`, which drives a real `Client` and calls `listTools()` before `callTool()`.

That ordering is the whole point. The SDK only validates `structuredContent` against the advertised schema once `tools/list` has armed the validators, so a test that calls handlers directly passes no matter what the schema says. That is why this shipped with 261 tests green.

Mutation-checked: reverting one schema to its previous shape makes the new test fail with the exact `-32602` from the issue.

## Verification

- `npm test` — 263 passing (16 files)
- `npm run typecheck` — clean on both halves